### PR TITLE
Replaced renamed pep8 with pycodestyle and added install dependency

### DIFF
--- a/flake8_todo.py
+++ b/flake8_todo.py
@@ -3,13 +3,13 @@ __version__ = '0.3'
 
 import re
 
-import pep8
+import pycodestyle
 
 NOTE_REGEX = re.compile(r'(TODO|FIXME|XXX)')  # noqa
 
 
 def check_todo_notes(physical_line):
-    if pep8.noqa(physical_line):
+    if pycodestyle.noqa(physical_line):
         return
     match = NOTE_REGEX.search(physical_line)
     if match:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
     url='https://github.com/schlamar/flake8-todo',
     license='MIT',
     py_modules=['flake8_todo'],
+    install_requires=[
+        'pycodestyle'
+    ],
     zip_safe=False,
     entry_points={
         'flake8.extension': [

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license='MIT',
     py_modules=['flake8_todo'],
     install_requires=[
-        'pycodestyle'
+        'pycodestyle >= 2.0.0, < 2.1.0'
     ],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
The pep8 module was renamed to pycodestyle. flake8 already switched to pycodestyle 2.0.0. Because of that using flake8 and flake8-todo results in a dependency glitch. I also added a install dependency on pycodestyle. Until now this dependency was only indirectly given because flake8 had a dependency on pep8.