### PR TITLE
feature: multiple codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7-dev'
+install:
+  - pip install pytest
+  - pip install .
+script:
+  - pytest
+cache: pip
+notifications:
+  email: false

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,21 @@ available in ``flake8``::
 Changes
 -------
 
+1.0 - 2019-03-07
+````````````````
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+
+* codes now begin with `TOD` instead of `T`
+* a line containing multiple `TODO` words will raise an error for each instance
+* different error codes for each word
+  * `TODO:  TOD000`
+  * `FIXME: TOD001`
+  * `XXX:   TOD002`
+* drop compatibility for `flake8 < 3.7.0`
+
+
 0.7 - 2016-11-15
 ````````````````
 

--- a/flake8_todo.py
+++ b/flake8_todo.py
@@ -1,20 +1,43 @@
-
-__version__ = '0.7'
+__version__ = "1.0"
 
 import re
 
 import pycodestyle
 
-NOTE_REGEX = re.compile(r'(TODO|FIXME|XXX)')  # noqa
+PLUGIN_ID = "TOD"
+
+
+def plugin_code(code):
+    return "".join((PLUGIN_ID, code))
+
+
+NOTE_WORDS = {
+    "TODO": {"code": plugin_code("000")},
+    "FIXME": {"code": plugin_code("001")},
+    "XXX": {"code": plugin_code("002")},
+}
+
+# Find any one of the note words definded above
+NOTE_REGEX = re.compile("\\b({})\\b".format("|".join(NOTE_WORDS)))
+
+
+def match_to_flake(match):
+    note_word = match.group(1)
+    note = NOTE_WORDS[note_word]
+    result = (
+        match.start(),
+        "{} Todo note found ({})".format(note["code"], note_word),
+    )
+    return result
 
 
 def check_todo_notes(physical_line):
     if pycodestyle.noqa(physical_line):
         return
-    match = NOTE_REGEX.search(physical_line)
-    if match:
-        return match.start(), 'T000 Todo note found.'
+    matches = NOTE_REGEX.finditer(physical_line)
+    for result in map(match_to_flake, matches):
+        yield result
 
 
-check_todo_notes.name = name = 'flake8-todo'
+check_todo_notes.name = name = "flake8-todo"
 check_todo_notes.version = __version__

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,13 @@ setup(
     license='MIT',
     py_modules=['flake8_todo'],
     install_requires=[
+        'flake8 >= 3.7.0',
         'pycodestyle >= 2.0.0, < 3.0.0'
     ],
     zip_safe=False,
     entry_points={
         'flake8.extension': [
-            'T000 = flake8_todo:check_todo_notes',
+            'TOD = flake8_todo:check_todo_notes',
         ],
     },
     classifiers=[

--- a/test_flake8_todo.py
+++ b/test_flake8_todo.py
@@ -1,0 +1,18 @@
+from flake8_todo import check_todo_notes
+
+T000 = "T000 Todo note found."
+
+
+def test_todo():
+    assert check_todo_notes("TODO this line") == (0, T000)
+    assert check_todo_notes("# TODO in comment") == (2, T000)
+    assert check_todo_notes("# FIXME") == (2, T000)
+    assert check_todo_notes("# XXX") == (2, T000)
+
+
+def test_todo_multiple():
+    assert check_todo_notes("# TODO FIXME") == (2, T000)
+
+
+def test_todo_word_boundaries():
+    assert check_todo_notes("# MASTODON") == (5, T000)

--- a/test_flake8_todo.py
+++ b/test_flake8_todo.py
@@ -1,18 +1,29 @@
 from flake8_todo import check_todo_notes
 
-T000 = "T000 Todo note found."
+TOD000 = "TOD000 Todo note found (TODO)"
+TOD001 = "TOD001 Todo note found (FIXME)"
+TOD002 = "TOD002 Todo note found (XXX)"
+
+
+def _check(line):
+    return list(check_todo_notes(line))
 
 
 def test_todo():
-    assert check_todo_notes("TODO this line") == (0, T000)
-    assert check_todo_notes("# TODO in comment") == (2, T000)
-    assert check_todo_notes("# FIXME") == (2, T000)
-    assert check_todo_notes("# XXX") == (2, T000)
+    assert _check("TODO this line") == [(0, TOD000)]
+    assert _check("# TODO in comment") == [(2, TOD000)]
+    assert _check("# FIXME") == [(2, TOD001)]
+    assert _check("# XXX") == [(2, TOD002)]
 
 
 def test_todo_multiple():
-    assert check_todo_notes("# TODO FIXME") == (2, T000)
+    assert _check("# TODO FIXME") == [(2, TOD000), (7, TOD001)]
 
 
 def test_todo_word_boundaries():
-    assert check_todo_notes("# MASTODON") == (5, T000)
+    assert _check("# MASTODON") == []
+    assert _check("#TODO") == [(1, TOD000)]
+
+
+def test_noqa():
+    assert _check("TODO # noqa") == []


### PR DESCRIPTION
Depends on #10 

Adds the ability to tell apart different `TODO` words. For instance, in our workflow:
- `TODO`s are allowed to be committed and fixed in the future, so I want to ignore them
- `FIXME`s and `XXX`s are not allowed to be committed, so I want to fail the build on them

Depends on `flake8 > 3.7.0`.

Breaking changes, so suggest bump to v1.